### PR TITLE
Add init file for all dot files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # dotfiles
+
 My dot files
+
+## Install
+
+```
+./init_dots.sh
+```

--- a/init_dots.sh
+++ b/init_dots.sh
@@ -1,0 +1,16 @@
+# Declare all dot files to version control
+# some examples of . files:
+# .bashrc
+# .bash_aliases
+# .inputrc
+# .gitconfig
+# .ideavimrc
+# .vimrc
+declare -a arr=(".vimrc")
+
+# Create symlinks from repo to HOME directory.
+for i in "${arr[@]}"
+do
+    DOT_SOURCE=$(realpath $i);
+    ln -sf $DOT_SOURCE ~/$i;
+done


### PR DESCRIPTION
Creates a symlink for all dotfiles named in the array.

If you'd like to do your spelling file to, include the following:

```bash
# Symlink vim spell file
mkdir -p ~/.vim/spell
ln -sf $(realpath en.utf-8.add) ~/.vim/spell/en.utf-8.add
```